### PR TITLE
use multi_json, ignore ASCII color in cli tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /.bundle/
 /.yardoc
 /Gemfile.lock
+/wss_agent.yml
 /_yardoc/
 /coverage/
 /doc/

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,5 @@ rvm:
   - 2.1.0
   - 2.0.0
   - 1.9.3
+  - jruby-19mode
+before_install: gem install bundler -v1.8.5

--- a/README.md
+++ b/README.md
@@ -8,10 +8,6 @@
         \/  \/   |_| |_|_|\__\___|_____/ \___/ \__,_|_|  \___\___(_)
 
 
-
-
-
-
 More about the White Source service : [http://www.whitesourcesoftware.com/](http://www.whitesourcesoftware.com/)
 
 View documentation here: [http://docs.whitesourcesoftware.com/display/serviceDocs/Ruby+Plugin](http://docs.whitesourcesoftware.com/display/serviceDocs/Ruby+Plugin)
@@ -24,6 +20,13 @@ View documentation here: [http://docs.whitesourcesoftware.com/display/serviceDoc
 $ gem install wss_agent
 ```
 
+##### Supported Rubies:
+
+- 2.2.0
+- 2.1.0
+- 2.0.0
+- 1.9.3
+- jruby-1.7.24 (jruby-19mode)
 
 ### 2) Initial configuration
 ```bash

--- a/Rakefile
+++ b/Rakefile
@@ -4,7 +4,7 @@ require "bundler/gem_tasks"
 # Default directory to look in is `/specs`
 # Run with `rake spec`
 RSpec::Core::RakeTask.new(:spec) do |task|
-  task.rspec_opts = ['--color', '--format']
+  task.rspec_opts = ['--color', '--format', 'documentation']
 end
 
 task :default => :spec

--- a/lib/wss_agent.rb
+++ b/lib/wss_agent.rb
@@ -2,7 +2,6 @@ require 'thor'
 require 'net/http'
 require 'awesome_print'
 require 'yaml'
-require 'oj'
 require 'faraday'
 require 'faraday_middleware'
 require 'yell'
@@ -16,7 +15,7 @@ require 'wss_agent/response_inventory'
 require 'wss_agent/client'
 require 'wss_agent/gem_sha1'
 require 'wss_agent/project'
-
+require 'multi_json'
 
 module WssAgent
   # Your code goes here...

--- a/lib/wss_agent/client.rb
+++ b/lib/wss_agent/client.rb
@@ -25,7 +25,7 @@ module WssAgent
       if Configure['project_token']
         diff_data['projectToken'] = Configure['project_token']
       end
-      Oj.dump([diff_data])
+      MultiJson.dump([diff_data])
     end
 
     def payload(gem_list, options = {})

--- a/lib/wss_agent/gem_sha1.rb
+++ b/lib/wss_agent/gem_sha1.rb
@@ -19,7 +19,7 @@ module WssAgent
         h.adapter :excon
       end
       response = conn.get("/api/v1/versions/#{spec.name}.json")
-      versions = Oj.load(response.body)
+      versions = MultiJson.load(response.body)
       unless versions.detect { |j| j['number'] == spec.version }
         spec.version = versions.first['number']
       end

--- a/lib/wss_agent/response.rb
+++ b/lib/wss_agent/response.rb
@@ -23,7 +23,7 @@ module WssAgent
     def parse_response
       if response.success?
         begin
-          @response_data = Oj.load(response.body)
+          @response_data = MultiJson.load(response.body)
           @status = @response_data['status'].to_i
           @message = @response_data['message']
         rescue
@@ -49,7 +49,7 @@ module WssAgent
     end
 
     def data
-      @data ||= Oj.load(response_data['data'])
+      @data ||= MultiJson.load(response_data['data'])
     rescue
       response_data && response_data.key?('data') ?  response_data['data'] : nil
     end

--- a/lib/wss_agent/response_policies.rb
+++ b/lib/wss_agent/response_policies.rb
@@ -5,7 +5,7 @@ module WssAgent
     def parse_response
       if response.success?
         begin
-          @response_data = Oj.load(response.body)
+          @response_data = MultiJson.load(response.body)
           @status = @response_data['status'].to_i
           @message = @response_data['message']
           check_new_projects

--- a/lib/wss_agent/specifications.rb
+++ b/lib/wss_agent/specifications.rb
@@ -120,7 +120,7 @@ module WssAgent
           h.adapter :excon
         end
         response = conn.get("/api/v1/gems/#{gem_name}.json")
-        dep_list = Oj.load(response.body)
+        dep_list = MultiJson.load(response.body)
         dep_list['dependencies'].values.flatten.
           map { |j| Gem::Dependency.new(j['name'], Gem::Requirement.new(j['requirements'].split(','))) }
       end

--- a/spec/wss_agent/cli_spec.rb
+++ b/spec/wss_agent/cli_spec.rb
@@ -1,6 +1,9 @@
 require 'spec_helper'
 
 describe WssAgent::CLI, vcr: true  do
+  def colorblind(str)
+    str.gsub(/\e\[([;\d]+)?m/, '')
+  end
 
   let(:cli) { WssAgent::CLI.new }
   subject { cli }
@@ -22,8 +25,27 @@ describe WssAgent::CLI, vcr: true  do
     it "returns a list dependies" do
       expect(WssAgent::Specifications).to receive(:list).and_return(list)
 
-      expect(output).to eq("[\n    \e[1;37m[0] \e[0m{\n           \"groupId\"\e[0;37m => \e[0m\e[0;33m\"rake\"\e[0m,\n        \"artifactId\"\e[0;37m => \e[0m\e[0;33m\"rake-10.4.2.gem\"\e[0m,\n           \"version\"\e[0;37m => \e[0m\e[0;33m\"10.4.2\"\e[0m,\n              \"sha1\"\e[0;37m => \e[0m\e[0;33m\"abfbf4fe8d3011f13f922adc81167af76890a627\"\e[0m,\n          \"optional\"\e[0;37m => \e[0m\e[1;31mfalse\e[0m,\n          \"children\"\e[0;37m => \e[0m[],\n        \"exclusions\"\e[0;37m => \e[0m[]\n    },\n    \e[1;37m[1] \e[0m{\n           \"groupId\"\e[0;37m => \e[0m\e[0;33m\"addressable\"\e[0m,\n        \"artifactId\"\e[0;37m => \e[0m\e[0;33m\"addressable-2.3.6.gem\"\e[0m,\n           \"version\"\e[0;37m => \e[0m\e[0;33m\"2.3.6\"\e[0m,\n              \"sha1\"\e[0;37m => \e[0m\e[0;33m\"dc3bdabbac99b05c3f9ec3b066ad1a41b6b55c55\"\e[0m,\n          \"optional\"\e[0;37m => \e[0m\e[1;31mfalse\e[0m,\n          \"children\"\e[0;37m => \e[0m[],\n        \"exclusions\"\e[0;37m => \e[0m[]\n    }\n]\n")
-
+      expect(colorblind(output)).to eq('''[
+    [0] {
+           "groupId" => "rake",
+        "artifactId" => "rake-10.4.2.gem",
+           "version" => "10.4.2",
+              "sha1" => "abfbf4fe8d3011f13f922adc81167af76890a627",
+          "optional" => false,
+          "children" => [],
+        "exclusions" => []
+    },
+    [1] {
+           "groupId" => "addressable",
+        "artifactId" => "addressable-2.3.6.gem",
+           "version" => "2.3.6",
+              "sha1" => "dc3bdabbac99b05c3f9ec3b066ad1a41b6b55c55",
+          "optional" => false,
+          "children" => [],
+        "exclusions" => []
+    }
+]
+''')
     end
   end
 
@@ -31,7 +53,7 @@ describe WssAgent::CLI, vcr: true  do
     let(:output) { capture(:stdout) { subject.update } }
     context 'when not found token' do
       it 'should display error message' do
-        expect(output).to eq("\e[1;31m\"Can't find Token, please add your Whitesource API token in the wss_agent.yml file\"\e[0m\n")
+        expect(colorblind(output)).to eq("\"Can't find Token, please add your Whitesource API token in the wss_agent.yml file\"\n")
       end
     end
     it 'should display results' do

--- a/wss_agent.gemspec
+++ b/wss_agent.gemspec
@@ -19,8 +19,8 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.executables   = %w(wss_agent)
-  spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "bundler", "~> 1.8.5"
   spec.add_development_dependency "pry", '~> 0.10', '>= 0.10.1'
   spec.add_development_dependency 'rspec', '~> 3.1', '>= 3.1.0'
   spec.add_development_dependency 'webmock', '~> 1.20', '>= 1.20.4'
@@ -34,5 +34,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'faraday', '~> 0.9', '>= 0.9.1'
   spec.add_dependency 'faraday_middleware', '~> 0.9', '>= 0.9.1'
   spec.add_dependency 'awesome_print', '~> 1.6', '>= 1.6.1'
-  spec.add_dependency 'oj', '~> 2.11', '>= 2.11.2'
+  spec.add_dependency 'multi_json', '~> 1.11'
 end


### PR DESCRIPTION
this replaces the `oj` JSON library with `multi_json` in order to support `wss_agent` usage on jruby. 

In addition to using `multi_json`, there were two modifications necessary to [get travis tests passing](https://travis-ci.org/nonrational/ruby-plugin/builds/127842955):
1. include a default `--format documentation` flag. maybe `--format` should be removed from the default rake task by default?
1. de-colorize the json output in the CLI spec. jruby + JSON doesn't include ASCII coloring in its output. I modified the specs to test the output contents without the color.
1. `2.0.0` and `2.1.0` wanted to install a different version of bundler. i just ensured travis uses 1.8.5.
