### PR TITLE
Set Excon ciphers to default when using JRuby.

### DIFF
--- a/lib/wss_agent/client.rb
+++ b/lib/wss_agent/client.rb
@@ -17,6 +17,9 @@ module WssAgent
         h.adapter :excon
       end
 
+      if defined?(JRuby)
+        Excon.defaults[:ciphers] = 'DEFAULT'
+      end
       @connection
     end
 


### PR DESCRIPTION
Hi!   My company uses whitesource to report on our dependencies in a Rails application running on JRuby.  We have been getting the following when checking policies:

```
bundle exec wss_agent check_policies
"error: 3/"
```

With `EXCON_DEBUG=true`:
```
excon.error
  :error => #<Excon::Error::Socket: no cipher match (OpenSSL::SSL::SSLError)>
```

This explicitly changes the cypher list back to defaults.  Thanks!